### PR TITLE
Simplified synching to make it a bit faster ( users complaining about performance )

### DIFF
--- a/src/main/java/net/jeymail/queue/conflating/ConflatingQueue.java
+++ b/src/main/java/net/jeymail/queue/conflating/ConflatingQueue.java
@@ -51,13 +51,13 @@ class ConflatingQueue {
      * Run from periodic timer, aimed at slow consumers only to control memory usage
      */
     public void sweep() {
-        synchronized (this.mutex) {
+        // used to be a synch on mutex here but don't need 
+        // since using LinkedBlockingQueue and ConcurrentHashMap
             if (this.queue.removeIf(m -> m.isConflatable()
                     && this.headIndex.getOrDefault(m.getKey(), m) != m)
             ) {
                 logger.info("Swept conflated messages");
             }
-        }
     }
 
     public AbstractMessage take()  {


### PR DESCRIPTION
Users complaining about performance, so removed this synch block that wasn't needed since all the data structures are already using concurrent versions.